### PR TITLE
keygenerator: pin elrond-go version to fix build

### DIFF
--- a/utils/elrond-go-keygenerator
+++ b/utils/elrond-go-keygenerator
@@ -1,6 +1,6 @@
 FROM golang:1.14.9 as builder
 
-RUN git clone https://github.com/ElrondNetwork/elrond-go.git
+RUN git clone https://github.com/ElrondNetwork/elrond-go.git && cd elrond-go && git checkout --force tags/v1.2.38
 
 #Build keygenerator
 WORKDIR /go/elrond-go/


### PR DESCRIPTION
utils/elrond-go-keygenerator now uses elrond-go
tag v1.2.38. This is the alligned with the tag
used in mainnet/elrond-node-obs.

Fixes #31