### PR TITLE
update go base image versions

### DIFF
--- a/covalent/observer/Dockerfile
+++ b/covalent/observer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7 as builder
+FROM golang:1.18 as builder
 
 ARG CONFIG_TAG
 ARG NETWORK

--- a/mainnet/elrond-node-obs
+++ b/mainnet/elrond-node-obs
@@ -1,4 +1,4 @@
-FROM golang:1.15.7 as builder
+FROM golang:1.18 as builder
 
 RUN git clone https://github.com/ElrondNetwork/elrond-config-mainnet && cd elrond-config-mainnet && git checkout --force tags/v1.2.38.1
 RUN git clone https://github.com/ElrondNetwork/elrond-go.git && cd elrond-go && git checkout --force tags/v1.2.38

--- a/mainnet/elrond-proxy
+++ b/mainnet/elrond-proxy
@@ -1,4 +1,4 @@
-FROM golang:1.15.7 as builder
+FROM golang:1.18 as builder
 
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh
 	

--- a/rosetta-devnet/observer/Dockerfile
+++ b/rosetta-devnet/observer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7 as builder
+FROM golang:1.18 as builder
 
 RUN git clone https://github.com/ElrondNetwork/elrond-config-devnet.git && cd elrond-config-devnet && git checkout --force tags/D1.2.30.0
 RUN git clone https://github.com/ElrondNetwork/elrond-go.git && cd elrond-go && git checkout --force tags/v1.2.30

--- a/rosetta-devnet/proxy/Dockerfile
+++ b/rosetta-devnet/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.9 as builder
+FROM golang:1.18 as builder
 
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh
 	

--- a/rosetta-mainnet/observer/Dockerfile
+++ b/rosetta-mainnet/observer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7 as builder
+FROM golang:1.18 as builder
 
 RUN git clone https://github.com/ElrondNetwork/elrond-config-mainnet && cd elrond-config-mainnet && git checkout --force tags/v1.2.30.1
 RUN git clone https://github.com/ElrondNetwork/elrond-go.git && cd elrond-go && git checkout --force tags/v1.2.30

--- a/rosetta-mainnet/proxy/Dockerfile
+++ b/rosetta-mainnet/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.9 as builder
+FROM golang:1.18 as builder
 
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh
 	

--- a/utils/elrond-go-keygenerator
+++ b/utils/elrond-go-keygenerator
@@ -1,4 +1,4 @@
-FROM golang:1.14.9 as builder
+FROM golang:1.18 as builder
 
 RUN git clone https://github.com/ElrondNetwork/elrond-go.git
 


### PR DESCRIPTION
This pull request updates the Go base image versions. Images were using a mix of Go versions 1.14 and 1.15, both are no longer supported or receiving important security fixes.

From https://go.dev/doc/devel/release:

> Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. We fix critical problems, including [critical security problems](https://go.dev/security), in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on).

Basically with the latest release earlier this month, only Go version 1.17 and 1.18 are still maintained. This PR upgrades directly to 1.18.

I've tested the build of all images, but not running all the variants. But since Go is a forward-compatible statically typed language this should be fine.

Note that the build of `utils/elrond-go-keygenerator` fails (also with the older version of Go) as reported in #31 and fix proposed in #32.