### PR TITLE
mainnet: drop to unprivileged user

### DIFF
--- a/mainnet/elrond-node-obs
+++ b/mainnet/elrond-node-obs
@@ -17,13 +17,19 @@ WORKDIR /go/elrond-config-mainnet/
 RUN cp -r * /go/elrond-go/cmd/node/config/
 
 # ===== SECOND STAGE ======
-FROM ubuntu:18.04
-COPY --from=builder "/go/elrond-go/cmd/node" "/go/elrond-go/cmd/node/"
+FROM ubuntu:20.04
+
+ENV workdir=/go/elrond-go/cmd/node
+ENV uid=1000
+RUN useradd -U -u ${uid} -d ${workdir} -M -s /sbin/nologin elrond
+
+COPY --from=builder "${workdir}" "${workdir}"
 COPY --from=builder "/lib/libwasmer_linux_amd64.so" "/lib/libwasmer_linux_amd64.so"
+COPY entrypoint.sh /
 
 #Enable "Database Lookup Extensions"
-WORKDIR /go/elrond-go/cmd/node/
+WORKDIR ${workdir}
 RUN sed -i '/\[DbLookupExtensions\]/!b;n;c\\tEnabled = true' ./config/config.toml
 
 EXPOSE 8080
-ENTRYPOINT ["/go/elrond-go/cmd/node/node", "--log-save", "--log-level=*:DEBUG,core/dblookupext:WARN", "--log-logger-name", "--rest-api-interface=0.0.0.0:8080"]
+ENTRYPOINT ["/entrypoint.sh", "/go/elrond-go/cmd/node/node", "--log-save", "--log-level=*:DEBUG,core/dblookupext:WARN", "--log-logger-name", "--rest-api-interface=0.0.0.0:8080"]

--- a/mainnet/elrond-proxy
+++ b/mainnet/elrond-proxy
@@ -10,13 +10,18 @@ WORKDIR /go/elrond-proxy-go/cmd/proxy
 RUN go build
 
 # ===== SECOND STAGE ======
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+ENV workdir=/go/elrond-proxy-go/cmd/proxy
+ENV uid=1000
+RUN useradd -U -u ${uid} -d ${workdir} -M -s /sbin/nologin elrond
 
 #Copy the built app to the container
-COPY --from=builder /go/elrond-proxy-go/cmd/proxy /go/elrond-proxy-go/cmd/proxy
-COPY configs/config.toml /go/elrond-proxy-go/cmd/proxy/config/
+COPY --from=builder "${workdir}" "${workdir}"
+COPY configs/config.toml ${workdir}/config/
+COPY entrypoint.sh /
 
-
-WORKDIR /go/elrond-proxy-go/cmd/proxy/
+WORKDIR ${workdir}
 EXPOSE 8079
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["./proxy"]

--- a/mainnet/entrypoint.sh
+++ b/mainnet/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+chown -R ${uid}:${uid} ${workdir}
+
+# set reduced priviledges
+exec setpriv --reuid=${uid} --regid=${uid} --init-groups $@


### PR DESCRIPTION
This change drops the root privileges to privilege-escalation attacks
from within the observer node and proxy containers.

In order not to import a third party tool like "GOSU",
ubuntu needed to be upgraded to 20.04.
This provides the setpriv command from the linux-util package,
included by default in the OS.

This follows the recommendation from https://docs.docker.com/engine/security/userns-remap/:

> The best way to prevent privilege-escalation attacks from within a container is to configure your container’s applications to run as unprivileged users.

I've only changed this in `mainnet`, because I'm familiar with running and testing it. The other variants, like `rosetta` and `covalent` I'm not familiar with and therefore did not want to break anything.