### PR TITLE
make the STACK_FOLDER_NAME configurable everywhere

### DIFF
--- a/covalent/.env
+++ b/covalent/.env
@@ -15,3 +15,5 @@ OBSERVER_DIR_M=~/MyObservingSquad/node-metachain
 
 
 NODE_TAG=elrond-go-node-development:latest
+
+STACK_FOLDER_NAME="~/MyObservingSquad"

--- a/covalent/docker-compose.yml
+++ b/covalent/docker-compose.yml
@@ -10,9 +10,9 @@ services:
    environment:
      - SHARD=0
    volumes:
-     - ~/MyObservingSquad/node-0/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-0/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-0/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-0/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-0/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-0/config:/config
    command: --destination-shard-as-observer=${SHARD_0} --validator-key-pem-file=/config/observerKey_${SHARD_0}.pem --display-name="${DISPLAY_NAME_0}" --config-external=/config/external.toml --rest-api-interface :8080
    networks:
      elrond-squad:
@@ -27,9 +27,9 @@ services:
    environment:
      - SHARD=1
    volumes:
-     - ~/MyObservingSquad/node-1/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-1/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-1/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-1/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-1/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-1/config:/config
    command: --destination-shard-as-observer=${SHARD_1} --validator-key-pem-file=/config/observerKey_${SHARD_1}.pem --display-name="${DISPLAY_NAME_1}" --config-external=/config/external.toml --rest-api-interface :8080
    networks:
      elrond-squad:
@@ -43,9 +43,9 @@ services:
    environment:
      - SHARD=2
    volumes:
-     - ~/MyObservingSquad/node-2/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-2/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-2/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-2/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-2/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-2/config:/config
    command: --destination-shard-as-observer=${SHARD_2} --validator-key-pem-file=/config/observerKey_${SHARD_2}.pem --display-name="${DISPLAY_NAME_2}" --config-external=/config/external.toml --rest-api-interface :8080
    networks:
      elrond-squad:
@@ -60,9 +60,9 @@ services:
    environment:
      - SHARD=metachain
    volumes:
-     - ~/MyObservingSquad/node-metachain/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-metachain/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-metachain/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-metachain/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-metachain/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-metachain/config:/config
    command: --destination-shard-as-observer=${SHARD_M} --validator-key-pem-file=/config/observerKey_${SHARD_M}.pem --display-name="${DISPLAY_NAME_M}" --config-external=/config/external.toml --rest-api-interface :8080
    networks:
      elrond-squad:

--- a/mainnet/.env
+++ b/mainnet/.env
@@ -20,3 +20,5 @@ IP_M=10.0.0.3
 
 NODE_TAG=elrond-node-obs:v1.2.38
 PROXY_TAG=elrond-proxy:v1.1.16
+
+STACK_FOLDER_NAME="~/MyObservingSquad"

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -9,9 +9,9 @@ services:
    environment:
      - SHARD=0
    volumes:
-     - ~/MyObservingSquad/node-0/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-0/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-0/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-0/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-0/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-0/config:/config
    command: --destination-shard-as-observer=${SHARD_0} --validator-key-pem-file=/config/observerKey_${SHARD_0}.pem --display-name="${DISPLAY_NAME_0}"
    networks:
      elrond-squad:
@@ -25,9 +25,9 @@ services:
    environment:
      - SHARD=1 
    volumes:
-     - ~/MyObservingSquad/node-1/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-1/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-1/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-1/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-1/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-1/config:/config
    command: --destination-shard-as-observer=${SHARD_1} --validator-key-pem-file=/config/observerKey_${SHARD_1}.pem --display-name="${DISPLAY_NAME_1}"
    networks:
      elrond-squad:
@@ -40,9 +40,9 @@ services:
    environment:
      - SHARD=2
    volumes:
-     - ~/MyObservingSquad/node-2/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-2/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-2/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-2/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-2/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-2/config:/config
    command: --destination-shard-as-observer=${SHARD_2} --validator-key-pem-file=/config/observerKey_${SHARD_2}.pem --display-name="${DISPLAY_NAME_2}"
    networks:
      elrond-squad:
@@ -56,9 +56,9 @@ services:
    environment:
      - SHARD=metachain
    volumes:
-     - ~/MyObservingSquad/node-metachain/db:/go/elrond-go/cmd/node/db
-     - ~/MyObservingSquad/node-metachain/logs:/go/elrond-go/cmd/node/logs
-     - ~/MyObservingSquad/node-metachain/config:/config
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-metachain/db:/go/elrond-go/cmd/node/db
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-metachain/logs:/go/elrond-go/cmd/node/logs
+     - ${STACK_FOLDER_NAME:-~/MyObservingSquad}/node-metachain/config:/config
    command: --destination-shard-as-observer=${SHARD_M} --validator-key-pem-file=/config/observerKey_${SHARD_M}.pem --display-name="${DISPLAY_NAME_M}"
    networks:
      elrond-squad:


### PR DESCRIPTION
Like the rosetta variants, mainnet and covenant now have
a configurable STACK_FOLDER_NAME variable.
Backwards compatibility is maintained by the variable defaults of
`~/MyObservingSquad` in docker-compose.yml.